### PR TITLE
ci: add trivy FS scanning for notebooks-v1 branch

### DIFF
--- a/.github/workflows/trivy-fs-scan.yaml
+++ b/.github/workflows/trivy-fs-scan.yaml
@@ -1,0 +1,35 @@
+name: Trivy FS scanning
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'  # Every Sunday at 6:00 AM UTC
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  security-events: write
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Run Trivy vulnerability scanner in fs mode
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        scan-type: 'fs'
+        scan-ref: '.'
+        format: 'sarif'
+        scanners: 'vuln,secret,misconfig'
+        severity: 'CRITICAL,HIGH'
+        ignore-unfixed: true
+        exit-code: 0
+        output: 'trivy-fs-scan-results.sarif'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+          sarif_file: 'trivy-fs-scan-results.sarif'


### PR DESCRIPTION
ℹ️ _NO GH ISSUE_

This commit provides a basic GHA to enable Trivy FS scanning on the notebooks-v1 branch.

It scans from the root of repo and reports on `CRITICAL` or `HIGH` vulnerabilities that have fixes available.  It will always exit with status code 0 and upload its results to the GitHub Security tab.

The workflow is configured to fire every Sunday at 6:00 AM UTC and also supports manually invoking it.  I personally did not see any reason to run this on pull_requests and/or pushes to `notebooks-v1` as vulnerabilities could be disclosed / fixes made available **at any time**.  Therefore, having it set on a weekly schedule as well as supported ad-hoc runs seems a reasonable way to manage.
