### PR TITLE
ci: add trivy FS scanning workflow

### DIFF
--- a/.github/workflows/trivy-fs-scan.yaml
+++ b/.github/workflows/trivy-fs-scan.yaml
@@ -1,0 +1,56 @@
+name: Trivy FS scanning
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'  # Every Sunday at 6:00 AM UTC
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to scan'
+        required: true
+        default: 'notebooks-v1'
+        type: choice
+        options:
+          - notebooks-v1
+          - notebooks-v2
+
+permissions:
+  actions: read
+  security-events: write
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', github.event.inputs.branch)) || fromJSON('["notebooks-v1", "notebooks-v2"]') }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.branch }}
+
+    - name: Run Trivy vulnerability scanner in fs mode
+      uses: aquasecurity/trivy-action@0.28.0
+      with:
+        scan-type: 'fs'
+        scan-ref: '.'
+        format: 'sarif'
+        scanners: 'vuln,secret,misconfig'
+        severity: 'CRITICAL,HIGH'
+        ignore-unfixed: true
+        exit-code: 0
+        output: 'trivy-fs-scan-results-${{ matrix.branch }}.sarif'
+
+    - name: Add branch metadata to SARIF
+      run: |
+        # Add category and modify ruleId to include branch information
+        jq '.runs[0].results[] |= (.category = "trivy-fs-scan-${{ matrix.branch }}" | .ruleId = "trivy-fs-${{ matrix.branch }}-" + .ruleId)' \
+           trivy-fs-scan-results-${{ matrix.branch }}.sarif > trivy-fs-scan-results-${{ matrix.branch }}-processed.sarif
+        mv trivy-fs-scan-results-${{ matrix.branch }}-processed.sarif trivy-fs-scan-results-${{ matrix.branch }}.sarif
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+          sarif_file: 'trivy-fs-scan-results-${{ matrix.branch }}.sarif'


### PR DESCRIPTION
This commit provides a basic GHA to enable Trivy FS scanning on the notebooks-v1 and notebooks-v2 branches.  In order to support `workflow_dispatch` and `cron` triggers - this GHA needs to live on the default branch (`main`).  But while the workflow lives on the `main` branch - it will only scan `notebooks-v1` and/or `notebooks-v2` branches depending on how its invoked.

It scans from the root of repo and reports on `CRITICAL` or `HIGH` vulnerabilities that have fixes available.  It will always exit with status code 0 and upload its results to the GitHub Security tab.  Custom category and ruleId metadata is injected into the report to help differentiate whether reported findings originated in `notebooks-v1` or `notebooks-v2`.

The workflow is configured to fire every Sunday at 6:00 AM UTC and also supports manually invoking it.  I personally did not see any reason to run this on pull_requests and/or pushes to `notebooks-v1` or `notebooks-v2` branches as vulnerabilities could be disclosed / fixes made available **at any time**.  Therefore, having it set on a weekly schedule as well as supported ad-hoc runs seems a reasonable way to manage.
