### PR TITLE
ci: add publish workflow for frontend

### DIFF
--- a/.github/workflows/ws-frontend-publish.yml
+++ b/.github/workflows/ws-frontend-publish.yml
@@ -1,0 +1,56 @@
+name: Build & Publish Frontend container image
+on:
+  push:
+    branches:
+      - main
+      - notebooks-v2
+      - v*-branch
+    paths:
+      - workspaces/**    ## NOTE: we publish changes on any commit to workspaces/frontend components
+      - releasing/version/VERSION
+
+env:
+  REGISTRY: ghcr.io/kubeflow/notebooks
+  NAME: workspaces-frontend
+
+jobs:
+  push_to_registry:
+    name: Build & Push container image to GHCR
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        base: ${{ github.ref }}
+        filters: |
+          version:
+            - 'releasing/version/VERSION'
+
+    - name: Login to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build and push multi-arch container image
+      run: |
+        cd workspaces/frontend
+        make docker-buildx REGISTRY=${REGISTRY} NAME=${NAME}
+
+    - name: Build and push multi-arch container image on Version change
+      id: version
+      if: steps.filter.outputs.version == 'true'
+      run: |
+        VERSION=$(cat releasing/version/VERSION)
+        cd workspaces/frontend
+        make docker-buildx REGISTRY=${REGISTRY} NAME=${NAME} TAG=${VERSION}

--- a/workspaces/frontend/Makefile
+++ b/workspaces/frontend/Makefile
@@ -1,5 +1,11 @@
+GIT_COMMIT     := $(shell git rev-parse HEAD)
+GIT_TREE_STATE := $(shell test -n "`git status --porcelain`" && echo "-dirty" || echo "")
+
 # Image URL to use for building/pushing the frontend image
-IMG ?= nbv2-frontend:latest
+REGISTRY ?= ghcr.io/kubeflow/notebooks
+NAME ?= workspaces-frontend
+TAG ?= sha-$(GIT_COMMIT)$(GIT_TREE_STATE)
+IMG ?= $(REGISTRY)/$(NAME):$(TAG)
 
 # CONTAINER_TOOL defines the container tool to be used for building images.
 # Tested with Docker by default. You may replace with podman.
@@ -39,7 +45,7 @@ docker-push: ## Push docker image for the frontend.
 	$(CONTAINER_TOOL) push ${IMG}
 
 # PLATFORMS defines the target platforms for cross-platform support.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
+PLATFORMS ?= linux/arm64/v8,linux/amd64,linux/s390x,linux/ppc64le
 
 .PHONY: docker-buildx
 docker-buildx: ## Build and push docker image for cross-platform support.


### PR DESCRIPTION
This commit adds a GHA workflow to support publishing a container image for the `workspaces/frontend` component as well as some updates to the `Makefile` to establish reasonable (but overridable) defaults.

Key behavior:
- Publishes frontend image on any workspaces/ directory change
- Builds image with commit SHA tags by default
    - "release" images with use the tag as defined by the `VERSION` file
    - a `-dirty` suffix is added to the tag if the codebase is not `porcelain`
    - no `latest` tag is ever produced on images
- Uses  `ghcr.io/kubeflow/notebooks` registry with configurable naming

example image name from "random" commit:
- `ghcr.io/kubeflow/notebooks/workspaces-frontend:sha-3fa851ab3173942dbaa1a609468e7f9eadf5f4e4`

example image name from release:
- `ghcr.io/kubeflow/notebooks/workspaces-frontend:v2.0.0`

