### PR TITLE
ci: fix ws-publish.yml

### DIFF
--- a/.github/workflows/ws-publish.yml
+++ b/.github/workflows/ws-publish.yml
@@ -62,7 +62,7 @@ jobs:
       tag_with_latest: false # we don't use 'latest' tags for workspace images
       tag_with_semver: ${{ needs.check_version.version_changed == 'true' }}
       tag_with_sha: true
-      semver_raw: ${{ needs.version.version_raw }}
+      semver_raw: ${{ needs.check_version.version_raw }}
       build_file: ${{ matrix.build_file }}
       build_context: ${{ matrix.build_context }}
       build_platforms: linux/amd64,linux/ppc64le,linux/arm64/v8


### PR DESCRIPTION
with.semver_raw has an incorrect reference to version_raw output that results in an empty string always being passed - which prevented semver tags from ever being produced (even when they should be)

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->