### PR TITLE
fix: semver with references

### DIFF
--- a/.github/workflows/ws-publish.yml
+++ b/.github/workflows/ws-publish.yml
@@ -60,9 +60,9 @@ jobs:
     with:
       image_name: ${{ matrix.image_name }}
       tag_with_latest: false # we don't use 'latest' tags for workspace images
-      tag_with_semver: ${{ needs.check_version.version_changed == 'true' }}
+      tag_with_semver: ${{ needs.check_version.outputs.version_changed == 'true' }}
       tag_with_sha: true
-      semver_raw: ${{ needs.check_version.version_raw }}
+      semver_raw: ${{ needs.check_version.outputs.version_raw }}
       build_file: ${{ matrix.build_file }}
       build_context: ${{ matrix.build_context }}
       build_platforms: linux/amd64,linux/ppc64le,linux/arm64/v8


### PR DESCRIPTION
needs.check_version stores all its 'interesting data' under the 'outputs' attribute.  This was not properly reflected in the 'with' block for images job.

<!-- 
⚠️ please review https://www.kubeflow.org/docs/about/contributing/

Thank you for contributing to Kubeflow!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->